### PR TITLE
feat(*): add remote backend support; add example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@
 /bin
 /terraform
 *-packr.go
+
+examples/**/cnab/app/mixins
+examples/**/cnab/app/porter-runtime
+examples/**/Dockerfile
+examples/**/bundle.json
+examples/**/bundle.cnab

--- a/examples/azure-aks/cnab/app/run
+++ b/examples/azure-aks/cnab/app/run
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec /cnab/app/porter-runtime run -f /cnab/app/porter.yaml

--- a/examples/azure-aks/cnab/app/terraform/aks.tf
+++ b/examples/azure-aks/cnab/app/terraform/aks.tf
@@ -1,0 +1,37 @@
+resource "azurerm_resource_group" "k8s" {
+    name     = "${var.resource_group_name}"
+    location = "${var.location}"
+}
+
+resource "azurerm_kubernetes_cluster" "k8s" {
+    name                = "${var.cluster_name}"
+    location            = "${azurerm_resource_group.k8s.location}"
+    resource_group_name = "${azurerm_resource_group.k8s.name}"
+    dns_prefix          = "${var.dns_prefix}"
+    kubernetes_version  = "${var.kubernetes_version}"
+
+    linux_profile {
+        admin_username = "ubuntu"
+
+        ssh_key {
+            key_data = "${var.ssh_public_key}"
+        }
+    }
+
+    agent_pool_profile {
+        name            = "default"
+        count           = "${var.agent_count}"
+        vm_size         = "Standard_DS2_v2"
+        os_type         = "Linux"
+        os_disk_size_gb = 30
+    }
+
+    service_principal {
+        client_id     = "${var.client_id}"
+        client_secret = "${var.client_secret}"
+    }
+
+    tags {
+        Environment = "Development"
+    }
+}

--- a/examples/azure-aks/cnab/app/terraform/main.tf
+++ b/examples/azure-aks/cnab/app/terraform/main.tf
@@ -1,0 +1,12 @@
+provider "azurerm" {
+    version = "~>1.5"
+    subscription_id = "${var.subscription_id}"
+    client_id       = "${var.client_id}"
+    client_secret   = "${var.client_secret}"
+    tenant_id       = "${var.tenant_id}"
+}
+
+terraform {
+    required_version = "~>0.11"
+    backend "azurerm" {}
+}

--- a/examples/azure-aks/cnab/app/terraform/output.tf
+++ b/examples/azure-aks/cnab/app/terraform/output.tf
@@ -1,19 +1,16 @@
-// TODO: designate appropriate values below as sensitive? (Perhaps optionally via bundle/mixin logic)
-//
-// See https://www.terraform.io/docs/configuration/outputs.html#sensitive-suppressing-values-in-cli-output
-// 
-// Otherwise, values will be printed out to console after each apply
-
 output "client_key" {
     value = "${azurerm_kubernetes_cluster.k8s.kube_config.0.client_key}"
+    sensitive = true
 }
 
 output "client_certificate" {
     value = "${azurerm_kubernetes_cluster.k8s.kube_config.0.client_certificate}"
+    sensitive = true
 }
 
 output "cluster_ca_certificate" {
     value = "${azurerm_kubernetes_cluster.k8s.kube_config.0.cluster_ca_certificate}"
+    sensitive = true
 }
 
 output "cluster_username" {
@@ -22,10 +19,12 @@ output "cluster_username" {
 
 output "cluster_password" {
     value = "${azurerm_kubernetes_cluster.k8s.kube_config.0.password}"
+    sensitive = true
 }
 
 output "kube_config" {
     value = "${azurerm_kubernetes_cluster.k8s.kube_config_raw}"
+    sensitive = true
 }
 
 output "host" {

--- a/examples/azure-aks/cnab/app/terraform/output.tf
+++ b/examples/azure-aks/cnab/app/terraform/output.tf
@@ -1,0 +1,33 @@
+// TODO: designate appropriate values below as sensitive? (Perhaps optionally via bundle/mixin logic)
+//
+// See https://www.terraform.io/docs/configuration/outputs.html#sensitive-suppressing-values-in-cli-output
+// 
+// Otherwise, values will be printed out to console after each apply
+
+output "client_key" {
+    value = "${azurerm_kubernetes_cluster.k8s.kube_config.0.client_key}"
+}
+
+output "client_certificate" {
+    value = "${azurerm_kubernetes_cluster.k8s.kube_config.0.client_certificate}"
+}
+
+output "cluster_ca_certificate" {
+    value = "${azurerm_kubernetes_cluster.k8s.kube_config.0.cluster_ca_certificate}"
+}
+
+output "cluster_username" {
+    value = "${azurerm_kubernetes_cluster.k8s.kube_config.0.username}"
+}
+
+output "cluster_password" {
+    value = "${azurerm_kubernetes_cluster.k8s.kube_config.0.password}"
+}
+
+output "kube_config" {
+    value = "${azurerm_kubernetes_cluster.k8s.kube_config_raw}"
+}
+
+output "host" {
+    value = "${azurerm_kubernetes_cluster.k8s.kube_config.0.host}"
+}

--- a/examples/azure-aks/cnab/app/terraform/params.tf
+++ b/examples/azure-aks/cnab/app/terraform/params.tf
@@ -1,0 +1,29 @@
+variable "client_id" {}
+variable "client_secret" {}
+variable "tenant_id" {}
+variable "subscription_id" {}
+variable "kubernetes_version" {}
+
+variable "agent_count" {
+    default = 1
+}
+
+variable "ssh_public_key" {
+    default = "~/.ssh/id_rsa.pub"
+}
+
+variable "dns_prefix" {
+    default = "akstest"
+}
+
+variable "cluster_name" {
+    default = "akstest"
+}
+
+variable "resource_group_name" {
+    default = "azure-akstest"
+}
+
+variable location {
+    default = "East US"
+}

--- a/examples/azure-aks/porter.yaml
+++ b/examples/azure-aks/porter.yaml
@@ -3,8 +3,7 @@ mixins:
 
 name: porter-aks
 version: 0.1.0
-# TODO: change image org
-invocationImage: quay.io/vdice/porter-aks:latest
+invocationImage: deislabs/porter-aks:latest
 
 credentials:
   - name: subscription_id
@@ -22,10 +21,16 @@ credentials:
   - name: ssh_public_key
     env: TF_VAR_ssh_public_key
 
+  - name: backend_storage_access_key
+    env: TF_VAR_backend_storage_access_key
+
+  - name: backend_storage_account
+    env: TF_VAR_backend_storage_account
+
+  - name: backend_storage_container
+    env: TF_VAR_backend_storage_container
+
 parameters:
-
-# AKS config
-
   - name: location
     type: string
     default: "East US"
@@ -62,39 +67,6 @@ parameters:
     destination:
       env: TF_VAR_resource_group_name
 
-# Backend config (using the azurerm backend provider)
-
-# TODO: put backend-related values up in creds, since they represent values for bundle infrastructure?
-
-  - name: backend_storage_account
-    type: string
-    default: "porteraksbackend"
-
-  - name: backend_storage_container
-    type: string
-    default: "porteraksbackend"
-
-  - name: backend_storage_access_key
-    type: string
-    sensitive: true
-
-# Action step definitions
-
-# TODO: pass in a backend init/prereqs script, to run prior to terraform init?
-#
-# For example, 'Create these backend resources required/used by terraform init...'
-
-# TODO: support for a separate, non-standard 'init' action that may be consumed during any standard action (install, uninstall, upgrade)?
-#
-# init:
-#   backendConfig:
-#     key: "{{ bundle.name }}.tfstate"
-#     storage_account_name: "{{ bundle.parameters.backend_storage_account }}"
-#     container_name: "{{ bundle.parameters.backend_storage_container }}"
-#     access_key: "{{ bundle.parameters.backend_storage_access_key }}"
-#
-# ...thus preventing duplication of same config for each standard action.
-
 install:
   - terraform:
       description: "Install Azure Kubernetes Service"
@@ -102,9 +74,9 @@ install:
       input: false
       backendConfig:
         key: "{{ bundle.name }}.tfstate"
-        storage_account_name: "{{ bundle.parameters.backend_storage_account }}"
-        container_name: "{{ bundle.parameters.backend_storage_container }}"
-        access_key: "{{ bundle.parameters.backend_storage_access_key }}"
+        storage_account_name: "{{ bundle.credentials.backend_storage_account }}"
+        container_name: "{{ bundle.credentials.backend_storage_container }}"
+        access_key: "{{ bundle.credentials.backend_storage_access_key }}"
 
 upgrade:
   - terraform:
@@ -113,18 +85,18 @@ upgrade:
       input: false
       backendConfig:
         key: "{{ bundle.name }}.tfstate"
-        storage_account_name: "{{ bundle.parameters.backend_storage_account }}"
-        container_name: "{{ bundle.parameters.backend_storage_container }}"
-        access_key: "{{ bundle.parameters.backend_storage_access_key }}"
+        storage_account_name: "{{ bundle.credentials.backend_storage_account }}"
+        container_name: "{{ bundle.credentials.backend_storage_container }}"
+        access_key: "{{ bundle.credentials.backend_storage_access_key }}"
 
 status:
   - terraform:
       description: "Get Azure Kubernetes Service status"
       backendConfig:
         key: "{{ bundle.name }}.tfstate"
-        storage_account_name: "{{ bundle.parameters.backend_storage_account }}"
-        container_name: "{{ bundle.parameters.backend_storage_container }}"
-        access_key: "{{ bundle.parameters.backend_storage_access_key }}"
+        storage_account_name: "{{ bundle.credentials.backend_storage_account }}"
+        container_name: "{{ bundle.credentials.backend_storage_container }}"
+        access_key: "{{ bundle.credentials.backend_storage_access_key }}"
 
 uninstall:
   - terraform:
@@ -132,6 +104,6 @@ uninstall:
       autoApprove: true
       backendConfig:
         key: "{{ bundle.name }}.tfstate"
-        storage_account_name: "{{ bundle.parameters.backend_storage_account }}"
-        container_name: "{{ bundle.parameters.backend_storage_container }}"
-        access_key: "{{ bundle.parameters.backend_storage_access_key }}"
+        storage_account_name: "{{ bundle.credentials.backend_storage_account }}"
+        container_name: "{{ bundle.credentials.backend_storage_container }}"
+        access_key: "{{ bundle.credentials.backend_storage_access_key }}"

--- a/examples/azure-aks/porter.yaml
+++ b/examples/azure-aks/porter.yaml
@@ -1,0 +1,137 @@
+mixins:
+  - terraform
+
+name: porter-aks
+version: 0.1.0
+# TODO: change image org
+invocationImage: quay.io/vdice/porter-aks:latest
+
+credentials:
+  - name: subscription_id
+    env: TF_VAR_subscription_id
+
+  - name: tenant_id
+    env: TF_VAR_tenant_id
+
+  - name: client_id
+    env: TF_VAR_client_id
+
+  - name: client_secret
+    env: TF_VAR_client_secret
+
+  - name: ssh_public_key
+    env: TF_VAR_ssh_public_key
+
+parameters:
+
+# AKS config
+
+  - name: location
+    type: string
+    default: "East US"
+    destination:
+      env: TF_VAR_location
+
+  - name: kubernetes_version
+    type: string
+    default: "1.12.7"
+    destination:
+      env: TF_VAR_kubernetes_version
+
+  - name: agent_count
+    type: integer
+    default: 1
+    destination:
+      env: TF_VAR_agent_count
+
+  - name: dns_prefix
+    type: string
+    default: "porteraks"
+    destination:
+      env: TF_VAR_dns_prefix
+
+  - name: cluster_name
+    type: string
+    default: "porteraks"
+    destination:
+      env: TF_VAR_cluster_name
+
+  - name: resource_group_name
+    type: string
+    default: "porteraks"
+    destination:
+      env: TF_VAR_resource_group_name
+
+# Backend config (using the azurerm backend provider)
+
+# TODO: put backend-related values up in creds, since they represent values for bundle infrastructure?
+
+  - name: backend_storage_account
+    type: string
+    default: "porteraksbackend"
+
+  - name: backend_storage_container
+    type: string
+    default: "porteraksbackend"
+
+  - name: backend_storage_access_key
+    type: string
+    sensitive: true
+
+# Action step definitions
+
+# TODO: pass in a backend init/prereqs script, to run prior to terraform init?
+#
+# For example, 'Create these backend resources required/used by terraform init...'
+
+# TODO: support for a separate, non-standard 'init' action that may be consumed during any standard action (install, uninstall, upgrade)?
+#
+# init:
+#   backendConfig:
+#     key: "{{ bundle.name }}.tfstate"
+#     storage_account_name: "{{ bundle.parameters.backend_storage_account }}"
+#     container_name: "{{ bundle.parameters.backend_storage_container }}"
+#     access_key: "{{ bundle.parameters.backend_storage_access_key }}"
+#
+# ...thus preventing duplication of same config for each standard action.
+
+install:
+  - terraform:
+      description: "Install Azure Kubernetes Service"
+      autoApprove: true
+      input: false
+      backendConfig:
+        key: "{{ bundle.name }}.tfstate"
+        storage_account_name: "{{ bundle.parameters.backend_storage_account }}"
+        container_name: "{{ bundle.parameters.backend_storage_container }}"
+        access_key: "{{ bundle.parameters.backend_storage_access_key }}"
+
+upgrade:
+  - terraform:
+      description: "Upgrade Azure Kubernetes Service"
+      autoApprove: true
+      input: false
+      backendConfig:
+        key: "{{ bundle.name }}.tfstate"
+        storage_account_name: "{{ bundle.parameters.backend_storage_account }}"
+        container_name: "{{ bundle.parameters.backend_storage_container }}"
+        access_key: "{{ bundle.parameters.backend_storage_access_key }}"
+
+status:
+  - terraform:
+      description: "Get Azure Kubernetes Service status"
+      backendConfig:
+        key: "{{ bundle.name }}.tfstate"
+        storage_account_name: "{{ bundle.parameters.backend_storage_account }}"
+        container_name: "{{ bundle.parameters.backend_storage_container }}"
+        access_key: "{{ bundle.parameters.backend_storage_access_key }}"
+
+uninstall:
+  - terraform:
+      description: "Uninstall Azure Kubernetes Service"
+      autoApprove: true
+      backendConfig:
+        key: "{{ bundle.name }}.tfstate"
+        storage_account_name: "{{ bundle.parameters.backend_storage_account }}"
+        container_name: "{{ bundle.parameters.backend_storage_container }}"
+        access_key: "{{ bundle.parameters.backend_storage_access_key }}"

--- a/pkg/terraform/helpers.go
+++ b/pkg/terraform/helpers.go
@@ -1,6 +1,7 @@
 package terraform
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/deislabs/porter/pkg/context"
@@ -20,4 +21,14 @@ func NewTestMixin(t *testing.T) *TestMixin {
 		Mixin:       m,
 		TestContext: c,
 	}
+}
+
+func sortKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	return keys
 }

--- a/pkg/terraform/helpers_test.go
+++ b/pkg/terraform/helpers_test.go
@@ -1,0 +1,23 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSortKeys(t *testing.T) {
+	m := map[string]string{
+		"delicious": "true",
+		"apples": "green",
+		"are": "needed",
+	}
+
+	expected := []string{
+		"apples",
+		"are",
+		"delicious",
+	}
+
+	assert.Equal(t, expected, sortKeys(m))
+}

--- a/pkg/terraform/init.go
+++ b/pkg/terraform/init.go
@@ -5,9 +5,19 @@ import (
 	"strings"
 )
 
-// Init runs terraform init
-func (m *Mixin) Init() error {
+// Init runs terraform init with the provided backendConfig, if supplied
+func (m *Mixin) Init(backendConfig map[string]string) error {
 	cmd := m.NewCommand("terraform", "init")
+
+	if len(backendConfig) > 0 {
+		cmd.Args = append(cmd.Args, "-backend=true")
+
+		for _, k := range sortKeys(backendConfig) {
+			cmd.Args = append(cmd.Args, fmt.Sprintf("-backend-config=%s=%s", k, backendConfig[k]))
+		}
+
+		cmd.Args = append(cmd.Args, "-reconfigure")
+	}
 
 	cmd.Stdout = m.Out
 	cmd.Stderr = m.Err

--- a/pkg/terraform/init_test.go
+++ b/pkg/terraform/init_test.go
@@ -14,7 +14,24 @@ func TestMixin_Init(t *testing.T) {
 
 	h := NewTestMixin(t)
 
-	err := h.Init()
+	err := h.Init(nil)
+
+	require.NoError(t, err)
+}
+
+func TestMixin_InitBackend(t *testing.T) {
+	defer os.Unsetenv(test.ExpectedCommandEnv)
+	os.Setenv(test.ExpectedCommandEnv,
+		"terraform init -backend=true -backend-config=donuts=definitely -backend-config=drink=dubonnet -reconfigure")
+
+	h := NewTestMixin(t)
+
+	backendConfig := map[string]string{
+		"drink": "dubonnet",
+		"donuts": "definitely",
+	}
+
+	err := h.Init(backendConfig)
 
 	require.NoError(t, err)
 }

--- a/pkg/terraform/install.go
+++ b/pkg/terraform/install.go
@@ -3,7 +3,6 @@ package terraform
 import (
 	"fmt"
 	"os"
-	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v2"
@@ -22,9 +21,11 @@ type InstallStep struct {
 type InstallArguments struct {
 	Step `yaml:",inline"`
 
-	AutoApprove bool              `yaml:"autoApprove"`
-	Vars        map[string]string `yaml:"vars"`
-	LogLevel    string            `yaml:"logLevel"`
+	AutoApprove   bool              `yaml:"autoApprove"`
+	Vars          map[string]string `yaml:"vars"`
+	LogLevel      string            `yaml:"logLevel"`
+	Input         bool              `yaml:"input"`
+	BackendConfig map[string]string `yaml:"backendConfig"`
 }
 
 // Install runs a terraform apply
@@ -55,7 +56,7 @@ func (m *Mixin) Install() error {
 
 	// Initialize Terraform
 	fmt.Println("Initializing Terraform...")
-	err = m.Init()
+	err = m.Init(step.BackendConfig)
 	if err != nil {
 		return fmt.Errorf("could not init terraform, %s", err)
 	}
@@ -67,14 +68,11 @@ func (m *Mixin) Install() error {
 		cmd.Args = append(cmd.Args, "-auto-approve")
 	}
 
-	// sort the vars consistently
-	varKeys := make([]string, 0, len(step.Vars))
-	for k := range step.Vars {
-		varKeys = append(varKeys, k)
+	if !step.Input {
+		cmd.Args = append(cmd.Args, "-input=false")
 	}
-	sort.Strings(varKeys)
 
-	for _, k := range varKeys {
+	for _, k := range sortKeys(step.Vars) {
 		cmd.Args = append(cmd.Args, "-var", fmt.Sprintf("%s=%s", k, step.Vars[k]))
 	}
 

--- a/pkg/terraform/install_test.go
+++ b/pkg/terraform/install_test.go
@@ -35,6 +35,7 @@ func TestMixin_UnmarshalInstallStep(t *testing.T) {
 
 	assert.Equal(t, "Install MySQL", step.Description)
 	assert.Equal(t, "TRACE", step.LogLevel)
+	assert.Equal(t, false, step.Input)
 }
 
 func TestMixin_Install(t *testing.T) {
@@ -42,7 +43,7 @@ func TestMixin_Install(t *testing.T) {
 		{
 			expectedCommand: strings.Join([]string{
 				"terraform init",
-				"terraform apply -auto-approve -var cool=true -var foo=bar",
+				"terraform apply -auto-approve -input=false -var cool=true -var foo=bar",
 			}, "\n"),
 			installStep: InstallStep{
 				InstallArguments: InstallArguments{

--- a/pkg/terraform/status.go
+++ b/pkg/terraform/status.go
@@ -21,7 +21,8 @@ type StatusStep struct {
 type StatusArguments struct {
 	Step `yaml:",inline"`
 
-	LogLevel string `yaml:"logLevel"`
+	LogLevel      string            `yaml:"logLevel"`
+	BackendConfig map[string]string `yaml:"backendConfig"`
 }
 
 // Status reports the status for infrastructure provisioned by Terraform
@@ -52,7 +53,7 @@ func (m *Mixin) Status() error {
 
 	// Initialize Terraform
 	fmt.Println("Initializing Terraform...")
-	err = m.Init()
+	err = m.Init(step.BackendConfig)
 	if err != nil {
 		return fmt.Errorf("could not init terraform, %s", err)
 	}

--- a/pkg/terraform/upgrade_test.go
+++ b/pkg/terraform/upgrade_test.go
@@ -29,6 +29,7 @@ func TestMixin_UnmarshalUpgradeStep(t *testing.T) {
 	step := action.Steps[0]
 
 	assert.Equal(t, "Upgrade MySQL", step.Description)
+	assert.Equal(t, false, step.Input)
 }
 
 func TestMixin_Upgrade(t *testing.T) {
@@ -36,7 +37,7 @@ func TestMixin_Upgrade(t *testing.T) {
 		{
 			expectedCommand: strings.Join([]string{
 				"terraform init",
-				"terraform apply -auto-approve -var cool=true -var foo=bar",
+				"terraform apply -auto-approve -input=false -var cool=true -var foo=bar",
 			}, "\n"),
 			upgradeStep: UpgradeStep{
 				UpgradeArguments: UpgradeArguments{


### PR DESCRIPTION
This PR adds the ability to use a backend with terraform.  An example bundle has been added utilizing this functionality. 

TODO:
 - [x] ~Wire up outputs~ edit: tracking in https://github.com/deislabs/porter-terraform/issues/11

Closes https://github.com/deislabs/porter-terraform/issues/7
Closes https://github.com/deislabs/porter-terraform/issues/4