### PR TITLE
Feat/outputs

### DIFF
--- a/examples/azure-keyvault/cnab/app/run
+++ b/examples/azure-keyvault/cnab/app/run
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec /cnab/app/porter-runtime run -f /cnab/app/porter.yaml

--- a/examples/azure-keyvault/cnab/app/terraform/keyvault.tf
+++ b/examples/azure-keyvault/cnab/app/terraform/keyvault.tf
@@ -1,0 +1,43 @@
+resource "azurerm_resource_group" "test" {
+    name     = "${var.resource_group_name}"
+    location = "${var.location}"
+}
+
+resource "azurerm_key_vault" "test" {
+    name                = "${var.keyvault_name}"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    enabled_for_disk_encryption = true
+    tenant_id                   = "${var.tenant_id}"
+
+    sku {
+        name = "standard"
+    }
+
+    access_policy {
+        tenant_id = "${var.tenant_id}"
+        object_id = "${var.client_id}"
+
+        key_permissions = [
+        "get",
+        ]
+
+        secret_permissions = [
+        "get",
+        ]
+
+        storage_permissions = [
+        "get",
+        ]
+    }
+
+    network_acls {
+        default_action = "Deny"
+        bypass         = "AzureServices"
+    }
+
+    tags = {
+        environment = "Production"
+    }
+}

--- a/examples/azure-keyvault/cnab/app/terraform/main.tf
+++ b/examples/azure-keyvault/cnab/app/terraform/main.tf
@@ -1,0 +1,12 @@
+provider "azurerm" {
+    version = "~>1.5"
+    subscription_id = "${var.subscription_id}"
+    client_id       = "${var.client_id}"
+    client_secret   = "${var.client_secret}"
+    tenant_id       = "${var.tenant_id}"
+}
+
+terraform {
+    required_version = "~>0.11"
+    backend "azurerm" {}
+}

--- a/examples/azure-keyvault/cnab/app/terraform/output.tf
+++ b/examples/azure-keyvault/cnab/app/terraform/output.tf
@@ -1,0 +1,7 @@
+output "id" {
+    value = "${azurerm_key_vault.test.id}"
+}
+
+output "vault_uri" {
+    value = "${azurerm_key_vault.test.vault_uri}"
+}

--- a/examples/azure-keyvault/cnab/app/terraform/params.tf
+++ b/examples/azure-keyvault/cnab/app/terraform/params.tf
@@ -1,0 +1,14 @@
+variable "client_id" {}
+variable "client_secret" {}
+variable "tenant_id" {}
+variable "subscription_id" {}
+
+variable "resource_group_name" {
+    default = "azure-kvtest"
+}
+
+variable location {
+    default = "East US"
+}
+
+variable "keyvault_name" {}

--- a/examples/azure-keyvault/porter.yaml
+++ b/examples/azure-keyvault/porter.yaml
@@ -1,0 +1,95 @@
+mixins:
+  - exec
+  - terraform
+
+name: porter-terraform-keyvault
+version: 0.1.0
+invocationImage: deislabs/porter-terraform-keyvault:latest
+
+credentials:
+  - name: subscription_id
+    env: TF_VAR_subscription_id
+
+  - name: tenant_id
+    env: TF_VAR_tenant_id
+
+  - name: client_id
+    env: TF_VAR_client_id
+
+  - name: client_secret
+    env: TF_VAR_client_secret
+
+  - name: backend_storage_access_key
+    env: TF_VAR_backend_storage_access_key
+
+  - name: backend_storage_account
+    env: TF_VAR_backend_storage_account
+
+  - name: backend_storage_container
+    env: TF_VAR_backend_storage_container
+
+parameters:
+  - name: keyvault_name
+    type: string
+    default: "porterkvtest"
+    destination:
+      env: TF_VAR_keyvault_name
+
+  - name: location
+    type: string
+    default: "East US"
+    destination:
+      env: TF_VAR_location
+
+  - name: resource_group_name
+    type: string
+    default: "porterkvtest"
+    destination:
+      env: TF_VAR_resource_group_name
+
+install:
+  - terraform:
+      description: "Install Azure Key Vault"
+      autoApprove: true
+      input: false
+      backendConfig:
+        key: "{{ bundle.name }}.tfstate"
+        storage_account_name: "{{ bundle.credentials.backend_storage_account }}"
+        container_name: "{{ bundle.credentials.backend_storage_container }}"
+        access_key: "{{ bundle.credentials.backend_storage_access_key }}"
+      outputs:
+      - name: vault_uri
+
+upgrade:
+  - terraform:
+      description: "Upgrade Azure Key Vault"
+      autoApprove: true
+      input: false
+      backendConfig:
+        key: "{{ bundle.name }}.tfstate"
+        storage_account_name: "{{ bundle.credentials.backend_storage_account }}"
+        container_name: "{{ bundle.credentials.backend_storage_container }}"
+        access_key: "{{ bundle.credentials.backend_storage_access_key }}"
+      outputs:
+      - name: vault_uri
+
+status:
+  - terraform:
+      description: "Get Azure Key Vault status"
+      backendConfig:
+        key: "{{ bundle.name }}.tfstate"
+        storage_account_name: "{{ bundle.credentials.backend_storage_account }}"
+        container_name: "{{ bundle.credentials.backend_storage_container }}"
+        access_key: "{{ bundle.credentials.backend_storage_access_key }}"
+      outputs:
+      - name: vault_uri
+
+uninstall:
+  - terraform:
+      description: "Uninstall Azure Key Vault"
+      autoApprove: true
+      backendConfig:
+        key: "{{ bundle.name }}.tfstate"
+        storage_account_name: "{{ bundle.credentials.backend_storage_account }}"
+        container_name: "{{ bundle.credentials.backend_storage_container }}"
+        access_key: "{{ bundle.credentials.backend_storage_access_key }}"

--- a/pkg/terraform/install.go
+++ b/pkg/terraform/install.go
@@ -92,5 +92,6 @@ func (m *Mixin) Install() error {
 		return err
 	}
 
+	m.handleOutputs(step.Outputs)
 	return nil
 }

--- a/pkg/terraform/status.go
+++ b/pkg/terraform/status.go
@@ -76,5 +76,6 @@ func (m *Mixin) Status() error {
 		return err
 	}
 
+	m.handleOutputs(step.Outputs)
 	return nil
 }

--- a/pkg/terraform/step.go
+++ b/pkg/terraform/step.go
@@ -1,12 +1,10 @@
 package terraform
 
 type Step struct {
-	Description string       `yaml:"description"`
+	Description string            `yaml:"description"`
 	Outputs     []terraformOutput `yaml:"outputs"`
 }
 
 type terraformOutput struct {
-	Name   string `yaml:"name"`
-	Secret string `yaml:"secret"`
-	Key    string `yaml:"key"`
+	Name string `yaml:"name"`
 }

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -2,7 +2,9 @@ package terraform
 
 import (
 	"bufio"
+	"fmt"
 	"io/ioutil"
+	"strings"
 
 	"github.com/deislabs/porter/pkg/context"
 	"github.com/pkg/errors"
@@ -29,4 +31,31 @@ func (m *Mixin) getPayloadData() ([]byte, error) {
 	reader := bufio.NewReader(m.In)
 	data, err := ioutil.ReadAll(reader)
 	return data, errors.Wrap(err, "could not read the payload from STDIN")
+}
+
+func (m *Mixin) getOutput(outputName string) (string, error) {
+	cmd := m.NewCommand("terraform", "output", outputName)
+	cmd.Stderr = m.Err
+
+	out, err := cmd.Output()
+	if err != nil {
+		prettyCmd := fmt.Sprintf("%s %s", cmd.Path, strings.Join(cmd.Args, " "))
+		return "", errors.Wrap(err, fmt.Sprintf("couldn't run command %s", prettyCmd))
+	}
+
+	return string(out), nil
+}
+
+func (m *Mixin) handleOutputs(outputs []terraformOutput) error {
+	var lines []string
+	for _, output := range outputs {
+		val, err := m.getOutput(output.Name)
+		if err != nil {
+			return err
+		}
+		l := fmt.Sprintf("%s=%s", output.Name, val)
+		lines = append(lines, l)
+	}
+	m.Context.WriteOutput(lines)
+	return nil
 }

--- a/pkg/terraform/uninstall.go
+++ b/pkg/terraform/uninstall.go
@@ -86,5 +86,6 @@ func (m *Mixin) Uninstall() error {
 		return err
 	}
 
+	m.handleOutputs(step.Outputs)
 	return nil
 }

--- a/pkg/terraform/upgrade.go
+++ b/pkg/terraform/upgrade.go
@@ -91,5 +91,6 @@ func (m *Mixin) Upgrade() error {
 		return err
 	}
 
+	m.handleOutputs(step.Outputs)
 	return nil
 }


### PR DESCRIPTION
* Adds output wiring for parity with other Porter mixins today.
* Adds a `porter-keyvault` example bundle utilizing outputs

Note: further work will be necessary in Porter and potentially this mixin itself to support multi-line outputs and/or file outputs.  Once done, we can update the `porter-aks` example bundle provide the generated kubeconfig file as an output, for instance.

Closes https://github.com/deislabs/porter-terraform/issues/11