### PR TITLE
Default approve

### DIFF
--- a/examples/azure-aks/porter.yaml
+++ b/examples/azure-aks/porter.yaml
@@ -75,7 +75,6 @@ customActions:
 install:
   - terraform:
       description: "Install Azure Kubernetes Service"
-      autoApprove: true
       input: false
       backendConfig:
         key: "{{ bundle.name }}.tfstate"
@@ -86,7 +85,6 @@ install:
 upgrade:
   - terraform:
       description: "Upgrade Azure Kubernetes Service"
-      autoApprove: true
       input: false
       backendConfig:
         key: "{{ bundle.name }}.tfstate"
@@ -106,7 +104,6 @@ show:
 uninstall:
   - terraform:
       description: "Uninstall Azure Kubernetes Service"
-      autoApprove: true
       backendConfig:
         key: "{{ bundle.name }}.tfstate"
         storage_account_name: "{{ bundle.credentials.backend_storage_account }}"

--- a/examples/azure-keyvault/porter.yaml
+++ b/examples/azure-keyvault/porter.yaml
@@ -55,7 +55,6 @@ customActions:
 install:
   - terraform:
       description: "Install Azure Key Vault"
-      autoApprove: true
       input: false
       backendConfig:
         key: "{{ bundle.name }}.tfstate"
@@ -68,7 +67,6 @@ install:
 upgrade:
   - terraform:
       description: "Upgrade Azure Key Vault"
-      autoApprove: true
       input: false
       backendConfig:
         key: "{{ bundle.name }}.tfstate"
@@ -92,7 +90,6 @@ show:
 uninstall:
   - terraform:
       description: "Uninstall Azure Key Vault"
-      autoApprove: true
       backendConfig:
         key: "{{ bundle.name }}.tfstate"
         storage_account_name: "{{ bundle.credentials.backend_storage_account }}"

--- a/examples/basic-tf-example/porter.yaml
+++ b/examples/basic-tf-example/porter.yaml
@@ -38,7 +38,6 @@ customActions:
 install:
   - terraform:
       description: "Install Terraform assets"
-      autoApprove: true
       outputs:
         - name: a
         - name: b
@@ -47,7 +46,6 @@ install:
 upgrade:
   - terraform:
       description: "Upgrade Terraform assets"
-      autoApprove: true
       outputs:
         - name: a
         - name: b
@@ -70,6 +68,5 @@ printVersion:
 
 uninstall:
   - terraform:
-      autoApprove: true
       description: "Uninstall Terraform assets"
 

--- a/pkg/terraform/install.go
+++ b/pkg/terraform/install.go
@@ -21,7 +21,9 @@ type InstallStep struct {
 type InstallArguments struct {
 	Step `yaml:",inline"`
 
+	// AutoApprove will be deprecated in a later release, it is no longer used, --auto-approve=true is always passed to terraform
 	AutoApprove   bool              `yaml:"autoApprove"`
+
 	Vars          map[string]string `yaml:"vars"`
 	LogLevel      string            `yaml:"logLevel"`
 	Input         bool              `yaml:"input"`
@@ -64,9 +66,8 @@ func (m *Mixin) Install() error {
 	// Run Terraform apply
 	cmd := m.NewCommand("terraform", "apply")
 
-	if step.AutoApprove {
-		cmd.Args = append(cmd.Args, "-auto-approve")
-	}
+	// Always run in non-interactive mode
+	cmd.Args = append(cmd.Args, "-auto-approve")
 
 	if !step.Input {
 		cmd.Args = append(cmd.Args, "-input=false")

--- a/pkg/terraform/install_test.go
+++ b/pkg/terraform/install_test.go
@@ -47,9 +47,8 @@ func TestMixin_Install(t *testing.T) {
 			}, "\n"),
 			installStep: InstallStep{
 				InstallArguments: InstallArguments{
-					Step: Step{Description: "Install"},
-					AutoApprove: true,
-					LogLevel:    "TRACE",
+					Step:     Step{Description: "Install"},
+					LogLevel: "TRACE",
 					Vars: map[string]string{
 						"cool": "true",
 						"foo":  "bar",

--- a/pkg/terraform/testdata/install-input.yaml
+++ b/pkg/terraform/testdata/install-input.yaml
@@ -1,7 +1,6 @@
 install:
 - terraform:
     description: "Install MySQL"
-    autoApprove: false
     input: false
     logLevel: TRACE
     backendConfig:

--- a/pkg/terraform/testdata/invoke-input.yaml
+++ b/pkg/terraform/testdata/invoke-input.yaml
@@ -3,7 +3,6 @@ custom:
     description: "Custom Action"
     command: "command-override"
     # Supports usual install args as well
-    autoApprove: false
     logLevel: TRACE
     backendConfig:
       key: "my.tfstate"

--- a/pkg/terraform/testdata/uninstall-input.yaml
+++ b/pkg/terraform/testdata/uninstall-input.yaml
@@ -1,7 +1,6 @@
 uninstall:
 - terraform:
     description: "Uninstall MySQL"
-    autoApprove: false
     logLevel: TRACE
     backendConfig:
       key: "my.tfstate"

--- a/pkg/terraform/testdata/upgrade-input.yaml
+++ b/pkg/terraform/testdata/upgrade-input.yaml
@@ -1,7 +1,6 @@
 upgrade:
 - terraform:
     description: "Upgrade MySQL"
-    autoApprove: false
     input: false
     logLevel: TRACE
     backendConfig:

--- a/pkg/terraform/uninstall.go
+++ b/pkg/terraform/uninstall.go
@@ -21,6 +21,7 @@ type UninstallStep struct {
 type UninstallArguments struct {
 	Step `yaml:",inline"`
 
+	// AutoApprove will be deprecated in a later release, it is no longer used, --auto-approve=true is always passed to terraform
 	AutoApprove   bool              `yaml:"autoApprove"`
 	Vars          map[string]string `yaml:"vars"`
 	LogLevel      string            `yaml:"logLevel"`
@@ -63,9 +64,8 @@ func (m *Mixin) Uninstall() error {
 	// Run terraform destroy
 	cmd := m.NewCommand("terraform", "destroy")
 
-	if step.AutoApprove {
-		cmd.Args = append(cmd.Args, "-auto-approve")
-	}
+	// Always run in non-interactive mode
+	cmd.Args = append(cmd.Args, "-auto-approve")
 
 	for _, k := range sortKeys(step.Vars) {
 		cmd.Args = append(cmd.Args, "-var", fmt.Sprintf("%s=%s", k, step.Vars[k]))

--- a/pkg/terraform/uninstall_test.go
+++ b/pkg/terraform/uninstall_test.go
@@ -41,7 +41,6 @@ func TestMixin_Uninstall(t *testing.T) {
 			uninstallStep: UninstallStep{
 				UninstallArguments: UninstallArguments{
 					Step: Step{Description: "Uninstall"},
-					AutoApprove: true,
 					Vars: map[string]string{
 						"cool": "true",
 						"foo":  "bar",

--- a/pkg/terraform/upgrade.go
+++ b/pkg/terraform/upgrade.go
@@ -21,6 +21,7 @@ type UpgradeStep struct {
 type UpgradeArguments struct {
 	Step `yaml:",inline"`
 
+	// AutoApprove will be deprecated in a later release, it is no longer used, --auto-approve=true is always passed to terraform
 	AutoApprove   bool              `yaml:"autoApprove"`
 	Vars          map[string]string `yaml:"vars"`
 	LogLevel      string            `yaml:"logLevel"`
@@ -64,9 +65,8 @@ func (m *Mixin) Upgrade() error {
 	// Run terraform apply
 	cmd := m.NewCommand("terraform", "apply")
 
-	if step.AutoApprove {
-		cmd.Args = append(cmd.Args, "-auto-approve")
-	}
+	// Always run in non-interactive mode
+	cmd.Args = append(cmd.Args, "-auto-approve")
 
 	if !step.Input {
 		cmd.Args = append(cmd.Args, "-input=false")

--- a/pkg/terraform/upgrade_test.go
+++ b/pkg/terraform/upgrade_test.go
@@ -41,8 +41,7 @@ func TestMixin_Upgrade(t *testing.T) {
 			}, "\n"),
 			upgradeStep: UpgradeStep{
 				UpgradeArguments: UpgradeArguments{
-					Step:        Step{Description: "Upgrade"},
-					AutoApprove: true,
+					Step: Step{Description: "Upgrade"},
 					Vars: map[string]string{
 						"cool": "true",
 						"foo":  "bar",


### PR DESCRIPTION
Bundles cannot run in an interactive prompt so we need to always run commands that do not trigger terraform to wait for user input. This deprecates the autoApprove field on all actions and always sets -auto-approve flag on terraform commands.

Once people have had a chance to stop setting the autoApprove field in their porter.yaml, we can update the mixin in a later release to remove the field entirely.

Closes #21 

I have tested this against Jeremy's do-porter demo.