### PR TITLE
feat(build.go): run terraform init (sans backend setup) on build

### DIFF
--- a/pkg/terraform/build.go
+++ b/pkg/terraform/build.go
@@ -8,9 +8,12 @@ const terraformClientVersion = "0.11.11"
 const dockerfileLines = `ENV TERRAFORM_VERSION=%s
 RUN apt-get update && apt-get install -y wget unzip && \
  wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
- unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/bin`
+ unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/bin
+COPY . $BUNDLE_DIR
+RUN cd %s && terraform init -backend=false
+`
 
 func (m *Mixin) Build() error {
-	fmt.Fprintf(m.Out, dockerfileLines, terraformClientVersion)
+	fmt.Fprintf(m.Out, dockerfileLines, terraformClientVersion, m.WorkingDir)
 	return nil
 }

--- a/pkg/terraform/build_test.go
+++ b/pkg/terraform/build_test.go
@@ -16,7 +16,10 @@ func TestMixin_Build(t *testing.T) {
 	wantOutput := `ENV TERRAFORM_VERSION=0.11.11
 RUN apt-get update && apt-get install -y wget unzip && \
  wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
- unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/bin`
+ unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/bin
+COPY . $BUNDLE_DIR
+RUN cd /cnab/app/terraform && terraform init -backend=false
+`
 
 	gotOutput := m.TestContext.GetOutput()
 	assert.Equal(t, wantOutput, gotOutput)


### PR DESCRIPTION
Runs `terraform init --backend=false` from the terraform working directory on mixin build, thereby fetching provider plugins at build-time.

Terraform will still be re-init-ed at runtime for all bundle actions in order to set up/using remote backends.  If done so at build-time, credentials and install-specific logic would be embedded in the base invocation image, which we don't wish to enable.

Closes https://github.com/deislabs/porter-terraform/issues/6 