### PR TITLE
ref(examples): update example manifests

### DIFF
--- a/examples/azure-aks/porter.yaml
+++ b/examples/azure-aks/porter.yaml
@@ -3,7 +3,7 @@ mixins:
 
 name: porter-aks
 version: 0.1.0
-invocationImage: deislabs/porter-aks:latest
+tag: deislabs/porter-aks:latest
 
 credentials:
   - name: subscription_id
@@ -34,38 +34,32 @@ parameters:
   - name: location
     type: string
     default: "East US"
-    destination:
-      env: TF_VAR_location
+    env: TF_VAR_location
 
   - name: kubernetes_version
     type: string
     default: "1.12.7"
-    destination:
-      env: TF_VAR_kubernetes_version
+    env: TF_VAR_kubernetes_version
 
   - name: agent_count
     type: integer
     default: 1
-    destination:
-      env: TF_VAR_agent_count
+    env: TF_VAR_agent_count
 
   - name: dns_prefix
     type: string
     default: "porteraks"
-    destination:
-      env: TF_VAR_dns_prefix
+    env: TF_VAR_dns_prefix
 
   - name: cluster_name
     type: string
     default: "porteraks"
-    destination:
-      env: TF_VAR_cluster_name
+    env: TF_VAR_cluster_name
 
   - name: resource_group_name
     type: string
     default: "porteraks"
-    destination:
-      env: TF_VAR_resource_group_name
+    env: TF_VAR_resource_group_name
 
 customActions:
   show:

--- a/examples/azure-keyvault/porter.yaml
+++ b/examples/azure-keyvault/porter.yaml
@@ -4,7 +4,7 @@ mixins:
 
 name: porter-terraform-keyvault
 version: 0.1.0
-invocationImage: deislabs/porter-terraform-keyvault:latest
+tag: deislabs/porter-terraform-keyvault:latest
 
 credentials:
   - name: subscription_id
@@ -32,20 +32,17 @@ parameters:
   - name: keyvault_name
     type: string
     default: "porterkvtest"
-    destination:
-      env: TF_VAR_keyvault_name
+    env: TF_VAR_keyvault_name
 
   - name: location
     type: string
     default: "East US"
-    destination:
-      env: TF_VAR_location
+    env: TF_VAR_location
 
   - name: resource_group_name
     type: string
     default: "porterkvtest"
-    destination:
-      env: TF_VAR_resource_group_name
+    env: TF_VAR_resource_group_name
 
 customActions:
   show:

--- a/examples/basic-tf-example/porter.yaml
+++ b/examples/basic-tf-example/porter.yaml
@@ -3,8 +3,7 @@ mixins:
 
 name: basic-tf-example
 version: 0.1.0
-invocationImage: basic-tf-example:latest
-tag: deislabs/basic-tf-example-bundle:v0.1.0
+tag: deislabs/basic-tf-example:v0.1.0
 
 outputs:
   - name: a


### PR DESCRIPTION
Updates example manifests to simplify (only provide `tag` now that `invocationImage` naming can be auto-inferred) and to fix per porter conventions (no `destination` object in a `parameter` definition).