### PR TITLE
ref(build): update Brigade CI

### DIFF
--- a/build/brigade.json
+++ b/build/brigade.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+      "@brigadecore/brigade-utils": "0.5.0"
+  }
+}


### PR DESCRIPTION
Updates Brigade CI per best practices/utilities; adds issue comment support.

I forgot we'd already switched to only running the Azure DevOps pipeline for this project.  Wanted to update the Brigade CI here regardless, just in case we dust it off in the future.

Tested locally via re-running some recent GH event webhooks.

Closes https://github.com/deislabs/porter-terraform/issues/43