### PR TITLE
fix(test-cli): fix test-cli script per porter usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ publish: bin/porter$(FILE_EXT)
 	az storage blob upload -c porter -n atom.xml -f bin/atom.xml
 
 bin/porter$(FILE_EXT):
+	mkdir -p $(BINDIR)
 	curl -fsSLo bin/porter$(FILE_EXT) https://cdn.porter.sh/canary/porter-$(CLIENT_PLATFORM)-$(CLIENT_ARCH)$(FILE_EXT)
 	chmod +x bin/porter$(FILE_EXT)
 

--- a/scripts/test/test-cli.sh
+++ b/scripts/test/test-cli.sh
@@ -20,8 +20,8 @@ ${PORTER_HOME}/porter build
 
 ${PORTER_HOME}/porter install --debug --param file_contents='foo!'
 
-echo "Verifying instance output(s) via 'porter instance outputs list' after install"
-list_outputs=$(${PORTER_HOME}/porter instance outputs list)
+echo "Verifying installation output(s) via 'porter installation outputs list' after install"
+list_outputs=$(${PORTER_HOME}/porter installation outputs list)
 echo "${list_outputs}"
 echo "${list_outputs}" | grep -q "file_contents"
 echo "${list_outputs}" | grep -q "foo!"
@@ -30,10 +30,8 @@ ${PORTER_HOME}/porter invoke --action=plan --debug
 
 ${PORTER_HOME}/porter upgrade --debug --param file_contents='bar!'
 
-echo "Verifying instance output(s) via 'porter instance output show' after upgrade"
-${PORTER_HOME}/porter instance output show file_contents | grep -q "bar!"
-
-cat ${PORTER_HOME}/claims/terraform.json
+echo "Verifying installation output(s) via 'porter installation output show' after upgrade"
+${PORTER_HOME}/porter installation output show file_contents | grep -q "bar!"
 
 ${PORTER_HOME}/porter uninstall --debug
 


### PR DESCRIPTION
* updates the cli test per updated Porter CLI commands
* creates the bin dir if necessary when downloading the porter CLI (needed if `make clean test-cli` is invoked, for example)