### PR TITLE
docs(*): update README around state; update basic example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a terraform mixin for [Porter](https://github.com/deislabs/porter).
 
 This will install the latest mixin release via the Porter CLI.
 
-```console
+```
 porter mixin install terraform --feed-url https://cdn.porter.sh/mixins/atom.xml
 ```
 

--- a/examples/basic-tf-example/porter.yaml
+++ b/examples/basic-tf-example/porter.yaml
@@ -1,73 +1,46 @@
 mixins:
-  - terraform
+  - terraform:
+      clientVersion: 0.12.29
 
 name: basic-tf-example
 version: 0.1.0
-tag: deislabs/basic-tf-example:v0.1.0
+tag: getporterci/basic-tf-example
 
 parameters:
-  - name: a
+  - name: tfstate
+    type: file
+    path: /cnab/app/terraform/terraform.tfstate
+    source:
+      output: tfstate
+  - name: myvar
     type: string
-    default: a
-  - name: b
-    type: string
-    default: b
-  - name: c
-    type: string
-    default: c
+    default: "porter rocks!"
 
 outputs:
-  - name: a
+  - name: tfstate
+    type: file
+    path: /cnab/app/terraform/terraform.tfstate
+  - name: myvar
     type: string
     applyTo:
       - install
       - upgrade
-  - name: b
-    type: string
-    applyTo:
-      - upgrade
-  - name: c
-    type: string
-    applyTo:
-      - install
-
-customActions:
-  plan:
-    description: "Invoke 'terraform plan'"
-    modifies: false
-    stateless: true
-  show:
-    description: "Invoke 'terraform show'"
-    modifies: false
-    stateless: true
-  printVersion:
-    description: "Invoke 'terraform version'"
-    modifies: false
-    stateless: true
 
 install:
   - terraform:
       description: "Install Terraform assets"
       vars:
-        a: "{{bundle.parameters.a}}"
-        b: "{{bundle.parameters.b}}"
-        c: "{{bundle.parameters.c}}"
+        myvar: "{{bundle.parameters.myvar}}"
       outputs:
-        - name: a
-        - name: b
-        - name: c
+        - name: myvar
 
 upgrade:
   - terraform:
       description: "Upgrade Terraform assets"
       vars:
-        a: "{{bundle.parameters.a}}"
-        b: "{{bundle.parameters.b}}"
-        c: "{{bundle.parameters.c}}"
+        myvar: "{{bundle.parameters.myvar}}"
       outputs:
-        - name: a
-        - name: b
-        - name: c
+        - name: myvar
 
 show:
   - terraform:
@@ -80,9 +53,7 @@ plan:
         no-color:
         out: "/dev/null"
         var:
-          - "a={{bundle.parameters.a}}"
-          - "b={{bundle.parameters.b}}"
-          - "c={{bundle.parameters.c}}"
+          - "myvar={{bundle.parameters.myvar}}"
 
 # Note: this can't be 'version:' as this would conflict with top-level field
 # Hence the need for the 'arguments:' override

--- a/examples/basic-tf-example/terraform/main.tf
+++ b/examples/basic-tf-example/terraform/main.tf
@@ -1,14 +1,4 @@
-resource "local_file" "a" {
-    content  = var.a
-    filename = "${path.module}/a"
-}
-
-resource "local_file" "b" {
-    content  = var.b
-    filename = "${path.module}/b"
-}
-
-resource "local_file" "c" {
-    content  = var.c
-    filename = "${path.module}/c"
+resource "local_file" "myvar" {
+    content  = var.myvar
+    filename = "${path.module}/myvar"
 }

--- a/examples/basic-tf-example/terraform/outputs.tf
+++ b/examples/basic-tf-example/terraform/outputs.tf
@@ -1,11 +1,3 @@
-output "a" {
-  value = var.a
-}
-
-output "b" {
-  value = var.b
-}
-
-output "c" {
-  value = var.c
+output "myvar" {
+  value = var.myvar
 }

--- a/examples/basic-tf-example/terraform/variables.tf
+++ b/examples/basic-tf-example/terraform/variables.tf
@@ -1,14 +1,4 @@
-variable "a" {
-  description = "Value for 'a'"
-  default = "a"
-}
-
-variable "b" {
-  description = "Value for 'b'"
-  default = "b"
-}
-
-variable "c" {
-  description = "Value for 'c'"
-  default = "c"
+variable "myvar" {
+  description = "Value for 'myvar'"
+  default = "myvar"
 }


### PR DESCRIPTION
* Updates the README with a sections/examples around patterns for tracking Terraform state
* Updates the "basic" terraform example to serve as an example harnessing Porter to track state

This PR should probably wait until Porter's forthcoming v0.28.0 release as it relies on unreleased/canary features.

~~(Note: CI needs https://github.com/deislabs/porter-terraform/pull/47 to pass)~~