### PR TITLE
fix(terraform.go): remove trailing newline from output value

### DIFF
--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -4,6 +4,7 @@ package terraform
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -53,9 +54,7 @@ func (m *Mixin) getOutput(outputName string) ([]byte, error) {
 	// Terraform appears to auto-append a newline character when printing outputs
 	// Trim this character before returning the output
 	out, err := cmd.Output()
-	if len(out) > 0 && out[len(out)-1] == '\n' {
-		out = out[0 : len(out)-1]
-	}
+	out = bytes.TrimRight(out, "\n")
 
 	if err != nil {
 		prettyCmd := fmt.Sprintf("%s %s", cmd.Path, strings.Join(cmd.Args, " "))

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -50,7 +50,13 @@ func (m *Mixin) getOutput(outputName string) ([]byte, error) {
 	cmd := m.NewCommand("terraform", "output", outputName)
 	cmd.Stderr = m.Err
 
+	// Terraform appears to auto-append a newline character when printing outputs
+	// Trim this character before returning the output
 	out, err := cmd.Output()
+	if len(out) > 0 && out[len(out)-1] == '\n' {
+		out = out[0 : len(out)-1]
+	}
+
 	if err != nil {
 		prettyCmd := fmt.Sprintf("%s %s", cmd.Path, strings.Join(cmd.Args, " "))
 		return nil, errors.Wrap(err, fmt.Sprintf("couldn't run command %s", prettyCmd))

--- a/scripts/test/test-cli.sh
+++ b/scripts/test/test-cli.sh
@@ -30,8 +30,18 @@ ${PORTER_HOME}/porter invoke --action=plan --debug
 
 ${PORTER_HOME}/porter upgrade --debug --param file_contents='bar!'
 
-echo "Verifying installation output(s) via 'porter installation output show' after upgrade"
-${PORTER_HOME}/porter installation output show file_contents | grep -q "bar!"
+echo "Verifying installation output via 'porter installation output show' after upgrade"
+# Verify the output matches the expected value
+if [[ "$(${PORTER_HOME}/porter installation output show file_contents)" != "bar!" ]]; then
+  echo "Output value: '${output}' does not match expected"
+  exit 1
+fi
+
+# Verify the output has no extra newline (mixin should trim newline added by terraform cli)
+if [[ "$(${PORTER_HOME}/porter installation output show file_contents | wc -l)" > 1 ]]; then
+  echo "Output has an extra newline character"
+  exit 1
+fi
 
 ${PORTER_HOME}/porter uninstall --debug
 

--- a/scripts/test/test-cli.sh
+++ b/scripts/test/test-cli.sh
@@ -10,6 +10,21 @@ mkdir -p ${TEST_DIR}
 pushd ${TEST_DIR}
 trap popd EXIT
 
+function verify-output() {
+  # Verify the output matches the expected value
+  if [[ "$(${PORTER_HOME}/porter installation output show $1)" != "$2" ]]; then
+    echo "Output '$1' value: '${output}' does not match expected"
+    return 1
+  fi
+
+  # Verify the output has no extra newline (mixin should trim newline added by terraform cli)
+  if [[ "$(${PORTER_HOME}/porter installation output show $1 | wc -l)" > 1 ]]; then
+    echo "Output '$1' has an extra newline character"
+    return 1
+  fi
+}
+
+
 # Copy terraform assets
 cp -r ${REPO_DIR}/build/testdata/bundles/terraform/terraform .
 
@@ -20,28 +35,14 @@ ${PORTER_HOME}/porter build
 
 ${PORTER_HOME}/porter install --debug --param file_contents='foo!'
 
-echo "Verifying installation output(s) via 'porter installation outputs list' after install"
-list_outputs=$(${PORTER_HOME}/porter installation outputs list)
-echo "${list_outputs}"
-echo "${list_outputs}" | grep -q "file_contents"
-echo "${list_outputs}" | grep -q "foo!"
+echo "Verifying installation output after install"
+verify-output "file_contents" 'foo!'
 
 ${PORTER_HOME}/porter invoke --action=plan --debug
 
 ${PORTER_HOME}/porter upgrade --debug --param file_contents='bar!'
 
-echo "Verifying installation output via 'porter installation output show' after upgrade"
-# Verify the output matches the expected value
-if [[ "$(${PORTER_HOME}/porter installation output show file_contents)" != "bar!" ]]; then
-  echo "Output value: '${output}' does not match expected"
-  exit 1
-fi
-
-# Verify the output has no extra newline (mixin should trim newline added by terraform cli)
-if [[ "$(${PORTER_HOME}/porter installation output show file_contents | wc -l)" > 1 ]]; then
-  echo "Output has an extra newline character"
-  exit 1
-fi
+echo "Verifying installation output after upgrade"
+verify-output "file_contents" 'bar!'
 
 ${PORTER_HOME}/porter uninstall --debug
-


### PR DESCRIPTION
* Removes the trailing newline from the output value returned from `terraform output <output name>` prior to bubbling up

Fixes https://github.com/deislabs/porter-terraform/issues/20

Note: Although the `--json` format flag on `terraform output` looks handy (as noted in https://github.com/deislabs/porter-terraform/issues/20#issuecomment-663593598) it appears the terraform CLI appends the newline character in this case as well -- and we'd have the extra task of removing the wrapping double quotes.  Hence, I went the simpler route and stuck with the default format.